### PR TITLE
Do not set TZID on a property if DateTimeValue is all-day

### DIFF
--- a/src/properties/property.js
+++ b/src/properties/property.js
@@ -479,7 +479,8 @@ export default class Property extends observerTrait(lockableTrait(class {})) {
 		const firstValue = this.getFirstValue()
 		if (firstValue instanceof DateTimeValue
 			&& firstValue.timezoneId !== 'floating'
-			&& firstValue.timezoneId !== 'UTC') {
+			&& firstValue.timezoneId !== 'UTC'
+			&& !firstValue.isDate) {
 			icalProperty.setParameter('tzid', firstValue.timezoneId)
 		}
 


### PR DESCRIPTION
Signed-off-by: Georg Ehrke <developer@georgehrke.com>